### PR TITLE
Fixes compatibility with latest fastlane version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ test-results
 # gems
 .bundle
 vendor/
+
+# Editor files
+.idea/

--- a/fastlane-plugin-repack_ios.gemspec
+++ b/fastlane-plugin-repack_ios.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |spec|
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency
 
-  spec.add_dependency('zip')
-
   spec.add_development_dependency('pry')
   spec.add_development_dependency('bundler')
   spec.add_development_dependency('rspec')

--- a/lib/fastlane/plugin/repack_ios/actions/repack_ios_action.rb
+++ b/lib/fastlane/plugin/repack_ios/actions/repack_ios_action.rb
@@ -1,4 +1,5 @@
 require 'fastlane/action'
+require 'gym'
 require_relative '../helper/repack_ios_helper'
 
 module Fastlane
@@ -29,6 +30,7 @@ module Fastlane
           UI.user_error!("Resolved ipa file: #{File.expand_path(ipa_path)} is not exists. Please provide ipa path.") unless File.exist?(ipa_path)
         else
           ipa_path = params[:ipa]
+          output_name = params[:output_name]
         end
 
         ipa_original_path = Helper::RepackIosHelper.unpack_and_repack(output_name, ipa_path, params[:contents])
@@ -174,6 +176,11 @@ module Fastlane
                                           UI.user_error!("Unsupported environment #{value}, must be in #{Match.environments.join(', ')}")
                                         end
                                       end),
+          FastlaneCore::ConfigItem.new(key: :output_name,
+                                      env_name: "FL_REPACK_IOS_OUTPUT_NAME",
+                                      description: "The name of the resulting app file inside the ipa file",
+                                      is_string: true,
+                                      optional: true),
           FastlaneCore::ConfigItem.new(key: :provisioning_profile,
                                       env_name: "FL_REPACK_IOS_PROVISIONING_PROFILE",
                                       description: "Path to your provisioning_profile. Optional if you use _sigh_ or _match_",


### PR DESCRIPTION
This PR fixes a couple of things:

- Fixes Gym object not being available in the current Fastlane version by `require 'gym'`
- Fixes `output_name` never being set if an ipa path is supplied.
- Removes `zip` dependency as it has been deprecated and the newest Fastlane version ships with `rubyzip` by default.